### PR TITLE
conditionally use doc_auto_cfg in docs.rs context only

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "megamind"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "A library for interacting with the Genius API."
 authors = ["Robert Yin <bobertoyin@gmail.com>"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
     unused_import_braces,
     unused_qualifications
 )]
-#![feature(doc_auto_cfg)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use std::{error::Error, fmt::Display};
 


### PR DESCRIPTION
The reason doc_auto_cfg is used in the first place is because docs.rs can leverage Rust nightly to include feature-specific documentation when building. However, we cannot expect library users to build with nightly, so it should not be used outside of a docs.rs context.