### PR TITLE
allow iq-by-action structs to have null fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "megamind"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "A library for interacting with the Genius API."
 authors = ["Robert Yin <bobertoyin@gmail.com>"]

--- a/src/models/metadata.rs
+++ b/src/models/metadata.rs
@@ -86,24 +86,29 @@ pub struct SongInteractions {
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, Default)]
 pub struct AnnotationActions {
     /// Accept.
-    pub accept: PrimaryAction,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub accept: Option<PrimaryAction>,
     /// Reject.
-    pub reject: PrimaryAction,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reject: Option<PrimaryAction>,
     /// Delete.
-    pub delete: PrimaryAction,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delete: Option<PrimaryAction>,
 }
 
 /// Song actions.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, Default)]
 pub struct SongActions {
     /// Edit metadata.
-    pub edit_metadata: PrimaryAction,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub edit_metadata: Option<PrimaryAction>,
 }
 
 /// Song relationships.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub struct SongRelationships {
     /// Pinned role.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub pinned_role: Option<String>,
 }
 


### PR DESCRIPTION
I don't have a conclusive answer for why these fields can be null, but my best guess is that auth tokens associated with a user will fill them in, but tokens that aren't associated with a user (client tokens) don't have any reasonable data for them.

While it certainly is inconvenient to have structs with all fields as Option<>, there's no way to discern between user tokens and client tokens.